### PR TITLE
fix: use video_key as merge task payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,8 @@ release-rocm-dev: pt-rocm pt-rocm-release-dev
 
 .PHONY: release-rocm
 release-rocm: pt-rocm pt-rocm-release
+
+.PHONY: dev
+dev:
+	docker compose -f ./deploy/docker-compose/lite/docker-compose.yml down
+	docker compose -f ./deploy/docker-compose/lite/docker-compose.yml up -d

--- a/common/task/type.go
+++ b/common/task/type.go
@@ -33,5 +33,5 @@ type EncodeTaskPayload struct {
 
 // MergeTaskPayload is a struct that represents the payload for merge task.
 type MergeTaskPayload struct {
-	Clips []db.VideoClipInfo `json:"clips"`
+	VideoKey string `json:"video_key"`
 }

--- a/server/internal/service/task/retry.go
+++ b/server/internal/service/task/retry.go
@@ -175,7 +175,7 @@ func HandleRetryMerge(req RetryMergeRequest) error {
 	}
 
 	payload, err := sonic.Marshal(task.MergeTaskPayload{
-		Clips: clips,
+		VideoKey: req.VideoKey,
 	})
 	if err != nil {
 		log.Logger.Error("Failed to marshal payload: " + err.Error())

--- a/server/internal/service/task/start.go
+++ b/server/internal/service/task/start.go
@@ -172,7 +172,7 @@ func HandleStart(req StartRequest) {
 	}
 
 	payload, err = sonic.Marshal(task.MergeTaskPayload{
-		Clips: clips,
+		VideoKey: req.VideoKey,
 	})
 	if err != nil {
 		log.Logger.Error("Failed to marshal payload: " + err.Error())


### PR DESCRIPTION
## Summary by Sourcery

Fix the merge task payload to use 'video_key' instead of 'clips', refactor the handler to accommodate this change, and update the Makefile with a new 'dev' target for Docker Compose management.

Bug Fixes:
- Fix the merge task payload to use 'video_key' instead of 'clips' for processing video tasks.

Enhancements:
- Refactor the merge task handler to retrieve video clips using 'video_key' and update logging to reflect this change.

Build:
- Add a new 'dev' target in the Makefile to manage Docker Compose services for development.