### PR TITLE
build: add docker persistent volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ tmp
 
 temp_clips
 temp_list.txt
+
+/deploy/docker-compose/allinone/

--- a/deploy/docker-compose/docker-compose-base.yml
+++ b/deploy/docker-compose/docker-compose-base.yml
@@ -17,6 +17,8 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=123456
       - MONGO_INITDB_DATABASE=finalrip
+    volumes:
+      - ./allinone/mongodb:/data/db
     networks:
       - backend
 
@@ -33,6 +35,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    volumes:
+      - ./allinone/redis:/data
     networks:
       - backend
 
@@ -59,6 +63,8 @@ services:
       MINIO_ROOT_USER: homo
       MINIO_ROOT_PASSWORD: homo114514
       MINIO_DEFAULT_BUCKETS: finalrip:public
+    volumes:
+      - ./allinone/minio:/bitnami/minio/data
     networks:
       - backend
 

--- a/deploy/docker-compose/docker-compose-encode.yml
+++ b/deploy/docker-compose/docker-compose-encode.yml
@@ -13,8 +13,6 @@ services:
     environment:
       #      - FINALRIP_REMOTE_CONFIG_HOST=EASYTIER
       - FINALRIP_REMOTE_CONFIG_HOST=consul:8500
-      - FINALRIP_DB_HOST=mongodb
-      - FINALRIP_REDIS_HOST=redis
     deploy:
       replicas: 1
       resources:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add persistent volumes for MongoDB, Redis, and Minio.