### PR TITLE
fix: "Starting new cluster due to timestamp" in subtitle merging

### DIFF
--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -93,21 +93,23 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		}
 	}
 
-	// 使用 mkvtoolnix 删除多余的 tags，重新混流
-	log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
-	// !mkvmerge -o output.mkv temp_merged.mkv
-	// !mkvpropedit output.mkv --tags all:
-	cmd = exec.Command(
-		"mkvmerge",
-		"-o", outputPath,
-		tempVideoMergedOutputPath,
-	)
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Logger.Errorf("Re-mux video failed: %v", err)
-		return err
-	}
-	log.Logger.Infof("Re-mux output: %s", out)
+	//// 使用 mkvtoolnix 删除多余的 tags，重新混流
+	//log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
+	//// !mkvmerge -o output.mkv temp_merged.mkv
+	//// !mkvpropedit output.mkv --tags all:
+	//cmd = exec.Command(
+	//	"mkvmerge",
+	//	"-o", outputPath,
+	//	tempVideoMergedOutputPath,
+	//)
+	//out, err = cmd.CombinedOutput()
+	//if err != nil {
+	//	log.Logger.Errorf("Re-mux video failed: %v", err)
+	//	return err
+	//}
+	//log.Logger.Infof("Re-mux output: %s", out)
+
+	_ = os.Rename(tempVideoMergedOutputPath, outputPath)
 	cmd = exec.Command(
 		"mkvpropedit",
 		outputPath,

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -117,19 +117,19 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 	//}
 	//log.Logger.Infof("ffmpeg Re-mux output: %s", out)
 
-	// use mkvpropedit to remove tags
-	// !mkvpropedit output.mkv --tags all:
-	cmd = exec.Command(
-		"mkvpropedit",
-		tempVideoMergedOutputPath,
-		"--tags", "all:",
-	)
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Logger.Errorf("mkvmerge remove tags failed: %v", err)
-		return err
-	}
-	log.Logger.Infof("mkvmerge remove tags output: %s", out)
+	//// use mkvpropedit to remove tags
+	//// !mkvpropedit output.mkv --tags all:
+	//cmd = exec.Command(
+	//	"mkvpropedit",
+	//	tempVideoMergedOutputPath,
+	//	"--tags", "all:",
+	//)
+	//out, err = cmd.CombinedOutput()
+	//if err != nil {
+	//	log.Logger.Errorf("mkvmerge remove tags failed: %v", err)
+	//	return err
+	//}
+	//log.Logger.Infof("mkvmerge remove tags output: %s", out)
 
 	// use mkvmerge to re-mux
 	// !mkvmerge -o output.mkv temp_merged.mkv

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -65,7 +65,7 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		"-c:v", "copy",
 		"-c:a", "flac",
 		"-c:s", "copy",
-		"max_interleave_delta", "0",
+		"-max_interleave_delta", "0",
 		tempVideoMergedOutputPath,
 	)
 	out, err = cmd.CombinedOutput()

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -11,11 +11,10 @@ import (
 
 // MergeVideo 使用 ffmpeg 进行视频合并，使用 mkvpropedit 清除 tags
 func MergeVideo(originFile string, inputFiles []string, outputPath string) error {
-	// 写入文件列表
-	listPath := "temp_list.txt"
+	listPath := "temp_list.txt" // 写入文件列表
 	tempVideoConcatOutputPath := "temp_video_concat_output.mkv"
 
-	// 清理临时文件
+	// clear temp file
 	_ = util.ClaerTempFile(listPath, tempVideoConcatOutputPath)
 	defer func(p ...string) {
 		log.Logger.Infof("Clear temp file %v", p)
@@ -70,7 +69,7 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 	out, err = cmd.CombinedOutput()
 	log.Logger.Infof("Merged output: %s", out)
 	if err != nil {
-		// 清理可能存在的临时文件
+		// clean maybe failed output
 		_ = util.ClaerTempFile(outputPath)
 		log.Logger.Errorf("Merge audio with audio and subtitle failed: %v, try to merge audio only", err)
 		// audio track

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -11,13 +11,14 @@ import (
 func MergeVideo(originFile string, inputFiles []string, outputPath string) error {
 	tempVideoConcatOutputPath := "temp_video_concat_output.mkv"
 	tempVideoMergedOutputPath := "temp_video_merged_output.mkv"
+	tempVideoOutputPath := "temp_video_output.mkv"
 
 	// 清理临时文件
-	_ = util.ClaerTempFile(tempVideoConcatOutputPath, tempVideoMergedOutputPath)
+	_ = util.ClaerTempFile(tempVideoConcatOutputPath, tempVideoMergedOutputPath, tempVideoOutputPath)
 	defer func(p ...string) {
 		log.Logger.Infof("Clear temp file %v", p)
 		_ = util.ClaerTempFile(p...)
-	}(tempVideoConcatOutputPath, tempVideoMergedOutputPath)
+	}(tempVideoConcatOutputPath, tempVideoMergedOutputPath, tempVideoOutputPath)
 
 	// Concat video
 	log.Logger.Infof("Concat video with encoded clips: %s", inputFiles)
@@ -81,21 +82,37 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		}
 	}
 
-	// 使用 mkvtoolnix 删除多余的 tags，重新混流
+	// use mkvmerge to re-mux
 	log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
 	// !mkvmerge -o output.mkv temp_merged.mkv
 	// !mkvpropedit output.mkv --tags all:
 	cmd = exec.Command(
 		"mkvmerge",
-		"-o", outputPath,
+		"-o", tempVideoOutputPath,
 		tempVideoMergedOutputPath,
 	)
 	out, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Logger.Errorf("Re-mux video failed: %v", err)
+		log.Logger.Errorf("mkvmerge Re-mux video failed: %v", err)
 		return err
 	}
-	log.Logger.Infof("Re-mux output: %s", out)
+	log.Logger.Infof("mkvmerge Re-mux output: %s", out)
+
+	// use ffmpeg to re-mux
+	cmd = exec.Command(
+		"ffmpeg",
+		"-i", tempVideoMergedOutputPath,
+		"-c", "copy",
+		outputPath,
+	)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		log.Logger.Errorf("ffmpeg Re-mux video failed: %v", err)
+		return err
+	}
+	log.Logger.Infof("ffmpeg Re-mux output: %s", out)
+
+	// use mkvpropedit to remove tags
 	cmd = exec.Command(
 		"mkvpropedit",
 		outputPath,
@@ -103,9 +120,9 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 	)
 	out, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Logger.Errorf("Remove tags failed: %v", err)
+		log.Logger.Errorf("mkvmerge remove tags failed: %v", err)
 		return err
 	}
-	log.Logger.Infof("Remove tags output: %s", out)
+	log.Logger.Infof("mkvmerge remove tags output: %s", out)
 	return nil
 }

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -82,13 +82,61 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		}
 	}
 
-	// use mkvmerge to re-mux
-	log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
-	// !mkvmerge -o output.mkv temp_merged.mkv
+	//err = os.Rename(tempVideoMergedOutputPath, outputPath)
+	//if err != nil {
+	//	log.Logger.Errorf("Rename video failed: %v", err)
+	//	return err
+	//}
+	//// use mkvmerge to re-mux
+	//log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
+	//// !mkvmerge -o output.mkv temp_merged.mkv
+	//// !mkvpropedit output.mkv --tags all:
+	//cmd = exec.Command(
+	//	"mkvmerge",
+	//	"-o", tempVideoOutputPath,
+	//	tempVideoMergedOutputPath,
+	//)
+	//out, err = cmd.CombinedOutput()
+	//if err != nil {
+	//	log.Logger.Errorf("mkvmerge Re-mux video failed: %v", err)
+	//	return err
+	//}
+	//log.Logger.Infof("mkvmerge Re-mux output: %s", out)
+	//
+	//// use ffmpeg to re-mux
+	//cmd = exec.Command(
+	//	"ffmpeg",
+	//	"-i", tempVideoMergedOutputPath,
+	//	"-c", "copy",
+	//	outputPath,
+	//)
+	//out, err = cmd.CombinedOutput()
+	//if err != nil {
+	//	log.Logger.Errorf("ffmpeg Re-mux video failed: %v", err)
+	//	return err
+	//}
+	//log.Logger.Infof("ffmpeg Re-mux output: %s", out)
+
+	// use mkvpropedit to remove tags
 	// !mkvpropedit output.mkv --tags all:
 	cmd = exec.Command(
+		"mkvpropedit",
+		tempVideoMergedOutputPath,
+		"--tags", "all:",
+	)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		log.Logger.Errorf("mkvmerge remove tags failed: %v", err)
+		return err
+	}
+	log.Logger.Infof("mkvmerge remove tags output: %s", out)
+
+	// use mkvmerge to re-mux
+	// !mkvmerge -o output.mkv temp_merged.mkv
+	log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
+	cmd = exec.Command(
 		"mkvmerge",
-		"-o", tempVideoOutputPath,
+		"-o", outputPath,
 		tempVideoMergedOutputPath,
 	)
 	out, err = cmd.CombinedOutput()
@@ -98,31 +146,5 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 	}
 	log.Logger.Infof("mkvmerge Re-mux output: %s", out)
 
-	// use ffmpeg to re-mux
-	cmd = exec.Command(
-		"ffmpeg",
-		"-i", tempVideoMergedOutputPath,
-		"-c", "copy",
-		outputPath,
-	)
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Logger.Errorf("ffmpeg Re-mux video failed: %v", err)
-		return err
-	}
-	log.Logger.Infof("ffmpeg Re-mux output: %s", out)
-
-	// use mkvpropedit to remove tags
-	cmd = exec.Command(
-		"mkvpropedit",
-		outputPath,
-		"--tags", "all:",
-	)
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Logger.Errorf("mkvmerge remove tags failed: %v", err)
-		return err
-	}
-	log.Logger.Infof("mkvmerge remove tags output: %s", out)
 	return nil
 }

--- a/module/ffmpeg/merge.go
+++ b/module/ffmpeg/merge.go
@@ -65,6 +65,7 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		"-c:v", "copy",
 		"-c:a", "flac",
 		"-c:s", "copy",
+		"max_interleave_delta", "0",
 		tempVideoMergedOutputPath,
 	)
 	out, err = cmd.CombinedOutput()
@@ -83,6 +84,7 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 			"-disposition:v:0", "default",
 			"-c:v", "copy",
 			"-c:a", "flac",
+			"-max_interleave_delta", "0",
 			tempVideoMergedOutputPath,
 		)
 		out, err = cmd.CombinedOutput()
@@ -93,23 +95,14 @@ func MergeVideo(originFile string, inputFiles []string, outputPath string) error
 		}
 	}
 
-	//// 使用 mkvtoolnix 删除多余的 tags，重新混流
-	//log.Logger.Infof("Re-mux video with mkvmerge and remove tags with mkvpropedit")
-	//// !mkvmerge -o output.mkv temp_merged.mkv
-	//// !mkvpropedit output.mkv --tags all:
-	//cmd = exec.Command(
-	//	"mkvmerge",
-	//	"-o", outputPath,
-	//	tempVideoMergedOutputPath,
-	//)
-	//out, err = cmd.CombinedOutput()
-	//if err != nil {
-	//	log.Logger.Errorf("Re-mux video failed: %v", err)
-	//	return err
-	//}
-	//log.Logger.Infof("Re-mux output: %s", out)
+	err = os.Rename(tempVideoMergedOutputPath, outputPath)
+	if err != nil {
+		log.Logger.Errorf("Rename temp video failed: %v", err)
+		return err
+	}
 
-	_ = os.Rename(tempVideoMergedOutputPath, outputPath)
+	// Remove tags with mkvpropedit
+	log.Logger.Infof("Remove tags with mkvpropedit...")
 	cmd = exec.Command(
 		"mkvpropedit",
 		outputPath,


### PR DESCRIPTION
https://github.com/TensoRaws/FinalRip/issues/48

## Summary by Sourcery

Fix subtitle merging issues and improve video processing.

Bug Fixes:
- Resolve "Starting new cluster due to timestamp" errors during subtitle merging.

Enhancements:
- Remove unnecessary tags using `mkvpropedit` during video merging.
- Use `-max_interleave_delta 0` to prevent timestamp issues and improve performance.