### PR TITLE
fix: more strict validation for encode param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO ?= go
 .DEFAULT_GOAL := default
 
 version := v0.2.2
-VS_PYTORCH_VERSION := dev
+VS_PYTORCH_VERSION := v0.2.0
 
 .PHONY: tidy
 tidy: ## go mod tidy

--- a/api.md
+++ b/api.md
@@ -15,7 +15,7 @@ search: true
 code_clipboard: true
 highlight_theme: darkula
 headingLevel: 2
-generator: "@tarslib/widdershins v4.0.23"
+generator: "@tarslib/widdershins v4.0.27"
 ---
 
 # FinalRip
@@ -47,7 +47,7 @@ script: "import os\r
   clip = core.bs.VideoSource(source=os.getenv('FINALRIP_SOURCE'))\r
 
   clip.set_output()"
-encode_param: ffmpeg -i - -vcodec libx265 -crf 16
+encode_param: ffmpeg -i - -vcodec libx265 -crf 16 FINALRIP_ENCODED_CLIP.mkv
 video_key: Roshidere-08.mkv
 slice: "true"
 timeout: 20

--- a/common/constant/constant.go
+++ b/common/constant/constant.go
@@ -3,7 +3,6 @@ package constant
 import (
 	"errors"
 	"strings"
-	"unicode"
 )
 
 type FinalRipConstant string
@@ -21,12 +20,14 @@ func CheckVSScriptAndEncodeParam(script string, encodeParam string) error {
 	if !strings.Contains(script, string(ENV_FINALRIP_SOURCE)) {
 		return errors.New("the VapourSynth Script code must contain " + string(ENV_FINALRIP_SOURCE) + " environment variable to specify the source video") //nolint:lll
 	}
+
 	if !strings.Contains(encodeParam, string(FINALRIP_ENCODED_CLIP_MKV)) {
 		return errors.New("the Encode Param must contain " + string(FINALRIP_ENCODED_CLIP_MKV) + " to specify the output video clip") //nolint:lll
 	}
-	encodeParam = strings.TrimRightFunc(encodeParam, unicode.IsSpace) // 去除末尾空格，换行符等
+
 	if strings.Contains(encodeParam, "\n") || strings.Contains(encodeParam, "\r") {
 		return errors.New("the Encode Param cannot contain line break")
 	}
+
 	return nil
 }

--- a/common/constant/constant.go
+++ b/common/constant/constant.go
@@ -1,6 +1,10 @@
 package constant
 
-import "strings"
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
 
 type FinalRipConstant string
 
@@ -12,7 +16,17 @@ const (
 	FINALRIP_ENCODED_CLIP_MKV = FINALRIP + FinalRipConstant("_ENCODED_CLIP.mkv")
 )
 
-// ContainsFinalRipInString 检查字符串中是否包含 FinalRip 常量
-func ContainsFinalRipInString(s string, constant FinalRipConstant) bool {
-	return strings.Contains(s, string(constant))
+// CheckVSScriptAndEncodeParam 检查传入的 Script 和 EncodeParam 是否合法
+func CheckVSScriptAndEncodeParam(script string, encodeParam string) error {
+	if !strings.Contains(script, string(ENV_FINALRIP_SOURCE)) {
+		return errors.New("the VapourSynth Script code must contain " + string(ENV_FINALRIP_SOURCE) + " environment variable to specify the source video") //nolint:lll
+	}
+	if !strings.Contains(encodeParam, string(FINALRIP_ENCODED_CLIP_MKV)) {
+		return errors.New("the Encode Param must contain " + string(FINALRIP_ENCODED_CLIP_MKV) + " to specify the output video clip") //nolint:lll
+	}
+	encodeParam = strings.TrimRightFunc(encodeParam, unicode.IsSpace) // 去除末尾空格，换行符等
+	if strings.Contains(encodeParam, "\n") || strings.Contains(encodeParam, "\r") {
+		return errors.New("the Encode Param cannot contain line break")
+	}
+	return nil
 }

--- a/module/ffmpeg/vapoursynth.go
+++ b/module/ffmpeg/vapoursynth.go
@@ -24,7 +24,7 @@ func EncodeVideo(encodeScript string, encodeParam string) error {
 		condaInitScript = "@echo off\r\n" + "call \"%USERPROFILE%\\miniconda3\\condabin\\activate.bat\"\r\n"
 	default:
 		scriptPath = "temp_script.sh"
-		condaInitScript = "#!/bin/bash\n" // linux 下默认激活 conda 环境
+		condaInitScript = "#!/bin/bash\n" // Linux 下默认激活 Conda 环境（v0.3后已经移除 Conda 环境
 	}
 	commandStr = condaInitScript + "vspipe -c y4m " + encodeScriptPath + " - | " + encodeParam
 	log.Logger.Info("Encode Command: " + commandStr)

--- a/server/internal/service/task/start.go
+++ b/server/internal/service/task/start.go
@@ -2,8 +2,10 @@ package task
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/TensoRaws/FinalRip/common/constant"
 	"github.com/TensoRaws/FinalRip/common/db"
@@ -35,6 +37,8 @@ func Start(c *gin.Context) {
 		return
 	}
 
+	// 去除末尾空格，换行符等
+	req.EncodeParam = strings.TrimRightFunc(req.EncodeParam, unicode.IsSpace)
 	// 检查传入的 Script 和 EncodeParam 是否合法
 	err := constant.CheckVSScriptAndEncodeParam(req.Script, req.EncodeParam)
 	if err != nil {

--- a/server/internal/service/task/start.go
+++ b/server/internal/service/task/start.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,11 +38,15 @@ func Start(c *gin.Context) {
 
 	// 检查传入的 Script 和 EncodeParam 是否合法
 	if !constant.ContainsFinalRipInString(req.Script, constant.ENV_FINALRIP_SOURCE) {
-		resp.AbortWithMsg(c, "VS script code must contain "+string(constant.ENV_FINALRIP_SOURCE)+" environment variable to specify the source video.") //nolint:lll
+		resp.AbortWithMsg(c, "VapourSynth Script code must contain "+string(constant.ENV_FINALRIP_SOURCE)+" environment variable to specify the source video.") //nolint:lll
 		return
 	}
 	if !constant.ContainsFinalRipInString(req.EncodeParam, constant.FINALRIP_ENCODED_CLIP_MKV) {
-		resp.AbortWithMsg(c, "Encode param must contain "+string(constant.FINALRIP_ENCODED_CLIP_MKV)+" to specify the output video clip.") //nolint:lll
+		resp.AbortWithMsg(c, "Encode Param must contain "+string(constant.FINALRIP_ENCODED_CLIP_MKV)+" to specify the output video clip.") //nolint:lll
+		return
+	}
+	if strings.Contains(req.EncodeParam, "/n") || strings.Contains(req.EncodeParam, "/r") {
+		resp.AbortWithMsg(c, "Encode Param cannot contain line break!!!")
 		return
 	}
 

--- a/server/internal/service/task/start.go
+++ b/server/internal/service/task/start.go
@@ -45,7 +45,7 @@ func Start(c *gin.Context) {
 		resp.AbortWithMsg(c, "Encode Param must contain "+string(constant.FINALRIP_ENCODED_CLIP_MKV)+" to specify the output video clip.") //nolint:lll
 		return
 	}
-	if strings.Contains(req.EncodeParam, "/n") || strings.Contains(req.EncodeParam, "/r") {
+	if strings.Contains(req.EncodeParam, "\n") || strings.Contains(req.EncodeParam, "\r") {
 		resp.AbortWithMsg(c, "Encode Param cannot contain line break!!!")
 		return
 	}

--- a/server/internal/service/task/start.go
+++ b/server/internal/service/task/start.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"errors"
-	"strings"
 	"sync"
 	"time"
 
@@ -37,16 +36,9 @@ func Start(c *gin.Context) {
 	}
 
 	// 检查传入的 Script 和 EncodeParam 是否合法
-	if !constant.ContainsFinalRipInString(req.Script, constant.ENV_FINALRIP_SOURCE) {
-		resp.AbortWithMsg(c, "VapourSynth Script code must contain "+string(constant.ENV_FINALRIP_SOURCE)+" environment variable to specify the source video.") //nolint:lll
-		return
-	}
-	if !constant.ContainsFinalRipInString(req.EncodeParam, constant.FINALRIP_ENCODED_CLIP_MKV) {
-		resp.AbortWithMsg(c, "Encode Param must contain "+string(constant.FINALRIP_ENCODED_CLIP_MKV)+" to specify the output video clip.") //nolint:lll
-		return
-	}
-	if strings.Contains(req.EncodeParam, "\n") || strings.Contains(req.EncodeParam, "\r") {
-		resp.AbortWithMsg(c, "Encode Param cannot contain line break!!!")
+	err := constant.CheckVSScriptAndEncodeParam(req.Script, req.EncodeParam)
+	if err != nil {
+		resp.AbortWithMsg(c, err.Error())
 		return
 	}
 
@@ -63,7 +55,7 @@ func Start(c *gin.Context) {
 	}
 
 	// 更新任务
-	err := db.UpdateTask(db.Task{Key: req.VideoKey}, db.Task{
+	err = db.UpdateTask(db.Task{Key: req.VideoKey}, db.Task{
 		EncodeParam: req.EncodeParam,
 		Script:      req.Script,
 	})

--- a/worker/internal/encode/worker.go
+++ b/worker/internal/encode/worker.go
@@ -84,7 +84,11 @@ func Handler(ctx context.Context, t *asynq.Task) error {
 
 	// 检查文件大小
 	if util.GetFileSize(tempEncodedVideo) < 8192 {
-		log.Logger.Errorf("Failed to encode video %s: file size is too small", util.StructToString(p.Clip))
+		log.Logger.Errorf("Failed to encode video %s: file size is too small, maybe GPU is offline, auto restart...", util.StructToString(p.Clip)) //nolint:lll
+		go func() {
+			time.Sleep(1 * time.Second)
+			os.Exit(114514)
+		}()
 		return errors.New("file size is too small")
 	}
 


### PR DESCRIPTION
https://github.com/TensoRaws/FinalRip/issues/72

## Summary by Sourcery

Enforce stricter validation rules for the encode parameter, requiring it to include "FINALRIP_ENCODED_CLIP.mkv" and disallowing line breaks.  Remove trailing whitespace from the encode parameter.

Bug Fixes:
- Fix an issue where invalid encode parameters were not being rejected.

Enhancements:
- Improve the validation of VapourSynth scripts and encode parameters.